### PR TITLE
Update ghostwriter/coding-standard to version dev-main#0320392

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1442,12 +1442,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "2defba4c2ec6d1f49126d4301dee269157d3b410"
+                "reference": "03203923d0deb11cd27c7eb59de04c94255882ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/2defba4c2ec6d1f49126d4301dee269157d3b410",
-                "reference": "2defba4c2ec6d1f49126d4301dee269157d3b410",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/03203923d0deb11cd27c7eb59de04c94255882ba",
+                "reference": "03203923d0deb11cd27c7eb59de04c94255882ba",
                 "shasum": ""
             },
             "require": {
@@ -1591,7 +1591,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-21T07:45:01+00:00"
+            "time": "2025-11-21T17:18:20+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#2defba4` to `dev-main#0320392`.

This pull request changes the following file(s): 

- Update `composer.lock`