### PR TITLE
Update ghostwriter/coding-standard to version dev-main#bb895f6

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1020,16 +1020,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.9.3",
+            "version": "2.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "fb3bee27676fd852a8a11ebbb1de19b4dada5aba"
+                "reference": "d4225153940b7c06f0e825195bdbdc312c67d917"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/fb3bee27676fd852a8a11ebbb1de19b4dada5aba",
-                "reference": "fb3bee27676fd852a8a11ebbb1de19b4dada5aba",
+                "url": "https://api.github.com/repos/composer/composer/zipball/d4225153940b7c06f0e825195bdbdc312c67d917",
+                "reference": "d4225153940b7c06f0e825195bdbdc312c67d917",
                 "shasum": ""
             },
             "require": {
@@ -1117,7 +1117,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.9.3"
+                "source": "https://github.com/composer/composer/tree/2.9.4"
             },
             "funding": [
                 {
@@ -1129,7 +1129,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-30T12:40:17+00:00"
+            "time": "2026-01-22T13:08:50+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -1508,18 +1508,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "00b9a33ef8c6e3fb2b1f5591a97ac90f5ac04738"
+                "reference": "bb895f65c0bedecafcf45879a08e2d6391a3c3b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/00b9a33ef8c6e3fb2b1f5591a97ac90f5ac04738",
-                "reference": "00b9a33ef8c6e3fb2b1f5591a97ac90f5ac04738",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/bb895f65c0bedecafcf45879a08e2d6391a3c3b1",
+                "reference": "bb895f65c0bedecafcf45879a08e2d6391a3c3b1",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "~2.9.0",
                 "composer-runtime-api": "~2.2.2",
-                "composer/composer": "^2.9.3",
+                "composer/composer": "^2.9.4",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -1688,7 +1688,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-16T20:09:39+00:00"
+            "time": "2026-01-22T17:39:34+00:00"
         },
         {
             "name": "ghostwriter/github-cli",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#00b9a33` to `dev-main#bb895f6`.

This pull request changes the following file(s): 

- Update `composer.lock`