### PR TITLE
Update symfony/console to version 8.0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ext-mbstring": "*",
         "ghostwriter/config": "^2.0.2",
         "ghostwriter/container": "^6.0.1",
-        "symfony/console": "^8.0.3"
+        "symfony/console": "^8.0.4"
     },
     "require-dev": {
         "ext-xdebug": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4728582546d87c5ab0a9ded87430c647",
+    "content-hash": "844a1a69b6b2c476d739f98cc36f5419",
     "packages": [
         {
             "name": "ghostwriter/config",
@@ -208,16 +208,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v8.0.3",
+            "version": "v8.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6145b304a5c1ea0bdbd0b04d297a5864f9a7d587"
+                "reference": "ace03c4cf9805080ff40cbeec69fca180c339a3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6145b304a5c1ea0bdbd0b04d297a5864f9a7d587",
-                "reference": "6145b304a5c1ea0bdbd0b04d297a5864f9a7d587",
+                "url": "https://api.github.com/repos/symfony/console/zipball/ace03c4cf9805080ff40cbeec69fca180c339a3b",
+                "reference": "ace03c4cf9805080ff40cbeec69fca180c339a3b",
                 "shasum": ""
             },
             "require": {
@@ -274,7 +274,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v8.0.3"
+                "source": "https://github.com/symfony/console/tree/v8.0.4"
             },
             "funding": [
                 {
@@ -294,7 +294,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-23T14:52:06+00:00"
+            "time": "2026-01-13T13:06:50+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",


### PR DESCRIPTION
Updates the `symfony/console` dependency from `v8.0.3` to `8.0.4`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`