### PR TITLE
Update ghostwriter/coding-standard to version dev-main#9bc242a

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1508,12 +1508,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "91c873c76d14f8b099fdd1530db7f93136380039"
+                "reference": "9bc242a401861477127dc9501ac135c8a117cadb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/91c873c76d14f8b099fdd1530db7f93136380039",
-                "reference": "91c873c76d14f8b099fdd1530db7f93136380039",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/9bc242a401861477127dc9501ac135c8a117cadb",
+                "reference": "9bc242a401861477127dc9501ac135c8a117cadb",
                 "shasum": ""
             },
             "require": {
@@ -1573,8 +1573,8 @@
                 "nikic/php-parser": "^5.7.0",
                 "php": "~8.4.0 || ~8.5.0",
                 "phpunit/phpunit": "^12.5.7",
-                "symfony/process": "^8.0.3",
-                "symfony/var-dumper": "^8.0.3"
+                "symfony/process": "^8.0.4",
+                "symfony/var-dumper": "^8.0.4"
             },
             "conflict": {
                 "pestphp/pest": "*"
@@ -1688,7 +1688,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-24T18:36:51+00:00"
+            "time": "2026-01-25T08:51:21+00:00"
         },
         {
             "name": "ghostwriter/github-cli",
@@ -4505,16 +4505,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v8.0.3",
+            "version": "v8.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "0cbbd88ec836f8757641c651bb995335846abb78"
+                "reference": "10df72602d88c0a3fa685b822976a052611dd607"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/0cbbd88ec836f8757641c651bb995335846abb78",
-                "reference": "0cbbd88ec836f8757641c651bb995335846abb78",
+                "url": "https://api.github.com/repos/symfony/process/zipball/10df72602d88c0a3fa685b822976a052611dd607",
+                "reference": "10df72602d88c0a3fa685b822976a052611dd607",
                 "shasum": ""
             },
             "require": {
@@ -4546,7 +4546,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v8.0.3"
+                "source": "https://github.com/symfony/process/tree/v8.0.4"
             },
             "funding": [
                 {
@@ -4566,7 +4566,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-19T10:01:18+00:00"
+            "time": "2026-01-23T11:07:10+00:00"
         },
         {
             "name": "symfony/var-dumper",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#91c873c` to `dev-main#9bc242a`.

This pull request changes the following file(s): 

- Update `composer.lock`