### PR TITLE
Update symfony/console to version 8.0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "ext-mbstring": "*",
         "ghostwriter/config": "^2.1.3",
         "ghostwriter/container": "^7.0.1",
-        "symfony/console": "^8.0.9"
+        "symfony/console": "^8.0.11"
     },
     "require-dev": {
         "ext-xdebug": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a34e85db2d571f0b3d66bf9abb9e8190",
+    "content-hash": "9bd59b52693004007bf7a5257ea7c1be",
     "packages": [
         {
             "name": "ghostwriter/config",
@@ -216,16 +216,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v8.0.9",
+            "version": "v8.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "7113778e2e91f4709cb3194a75dfa9c0d028d94d"
+                "reference": "3156577f46a38aa1b9323aad223de7a9cd426782"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/7113778e2e91f4709cb3194a75dfa9c0d028d94d",
-                "reference": "7113778e2e91f4709cb3194a75dfa9c0d028d94d",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3156577f46a38aa1b9323aad223de7a9cd426782",
+                "reference": "3156577f46a38aa1b9323aad223de7a9cd426782",
                 "shasum": ""
             },
             "require": {
@@ -282,7 +282,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v8.0.9"
+                "source": "https://github.com/symfony/console/tree/v8.0.11"
             },
             "funding": [
                 {
@@ -302,7 +302,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T15:02:55+00:00"
+            "time": "2026-05-13T12:07:53+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -891,16 +891,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "cd626ff2604e98e045427b7d1a6493632a351156"
+                "reference": "9cae458f50d3633a33f59c1382bcc8cbee17639d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/cd626ff2604e98e045427b7d1a6493632a351156",
-                "reference": "cd626ff2604e98e045427b7d1a6493632a351156",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/9cae458f50d3633a33f59c1382bcc8cbee17639d",
+                "reference": "9cae458f50d3633a33f59c1382bcc8cbee17639d",
                 "shasum": ""
             },
             "require": {
@@ -948,7 +948,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.5.0"
+                "source": "https://github.com/boundwize/structarmed/tree/0.5.1"
             },
             "funding": [
                 {
@@ -956,7 +956,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-13T01:30:23+00:00"
+            "time": "2026-05-13T16:56:25+00:00"
         },
         {
             "name": "ghostwriter/coding-standard",
@@ -964,16 +964,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "9109490996ef84a94bc6882b8aebb553d2e98065"
+                "reference": "c840eb81ef74b5ba5faff7c3616888b026e177ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/9109490996ef84a94bc6882b8aebb553d2e98065",
-                "reference": "9109490996ef84a94bc6882b8aebb553d2e98065",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/c840eb81ef74b5ba5faff7c3616888b026e177ab",
+                "reference": "c840eb81ef74b5ba5faff7c3616888b026e177ab",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.5.0",
+                "boundwize/structarmed": "^0.5.1",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -1084,7 +1084,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-13T12:28:54+00:00"
+            "time": "2026-05-13T22:09:21+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `symfony/console` dependency from `v8.0.9` to `8.0.11`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`