### PR TITLE
Update `ghostwriter/event-dispatcher` to version `6.1.3`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1331,16 +1331,16 @@
         },
         {
             "name": "ghostwriter/event-dispatcher",
-            "version": "6.1.2",
+            "version": "6.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/event-dispatcher.git",
-                "reference": "617c1ee6cd63407ad9f9932e4a2833fb226f574e"
+                "reference": "f09567008800086371068ff52d6ca418aeabbca8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/event-dispatcher/zipball/617c1ee6cd63407ad9f9932e4a2833fb226f574e",
-                "reference": "617c1ee6cd63407ad9f9932e4a2833fb226f574e",
+                "url": "https://api.github.com/repos/ghostwriter/event-dispatcher/zipball/f09567008800086371068ff52d6ca418aeabbca8",
+                "reference": "f09567008800086371068ff52d6ca418aeabbca8",
                 "shasum": ""
             },
             "require": {
@@ -1411,7 +1411,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-29T20:47:09+00:00"
+            "time": "2026-05-29T22:38:50+00:00"
         },
         {
             "name": "ghostwriter/filesystem",


### PR DESCRIPTION
Updates the [`ghostwriter/event-dispatcher`](https://packagist.org/packages/ghostwriter/event-dispatcher) dependency from `6.1.2` to `6.1.3`.

This pull request changes the following file(s): 

- Update `composer.lock`