### PR TITLE
Update `boundwize/structarmed` to version `0.12.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.11.3",
+        "boundwize/structarmed": "^0.12.0",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/phpunit-assertions": "^0.1.0",
         "ghostwriter/testify": "^0.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2aa6be4fe2588406c02dbd9b3d56f96",
+    "content-hash": "8d97d3f4aa4381db2efc4f46ac855761",
     "packages": [
         {
             "name": "ghostwriter/config",
@@ -983,16 +983,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.11.3",
+            "version": "0.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "42a2520eda670609d701f9e6704b7d31d8d8b697"
+                "reference": "e3b038b0675e0b1e3c056dc8e4ffcbab15b39bf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/42a2520eda670609d701f9e6704b7d31d8d8b697",
-                "reference": "42a2520eda670609d701f9e6704b7d31d8d8b697",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/e3b038b0675e0b1e3c056dc8e4ffcbab15b39bf8",
+                "reference": "e3b038b0675e0b1e3c056dc8e4ffcbab15b39bf8",
                 "shasum": ""
             },
             "require": {
@@ -1045,7 +1045,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.11.3"
+                "source": "https://github.com/boundwize/structarmed/tree/0.12.0"
             },
             "funding": [
                 {
@@ -1053,7 +1053,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-04T16:05:09+00:00"
+            "time": "2026-06-05T02:51:34+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the [`boundwize/structarmed`](https://packagist.org/packages/boundwize/structarmed) dependency from `0.11.3` to `0.12.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`